### PR TITLE
set nil to eventCh to avoid to handle resize event

### DIFF
--- a/tui/tui.go
+++ b/tui/tui.go
@@ -161,6 +161,7 @@ func (ui *Tui) drawCompletionResults(s state.State, width int, height int) {
 
 // Close terminates the Tui.
 func (ui *Tui) Close() error {
+	ui.eventCh = nil
 	ui.screen.Fini()
 	<-ui.waitCh
 	return nil


### PR DESCRIPTION
set nil to eventCh since remaining events in eventCh will be triggerd while exiting on Windows.