### PR TITLE
Exit cmdline when trying to delete an empty cmdline buffer by backspace

### DIFF
--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -113,6 +113,10 @@ func (c *Cmdline) backspace() {
 	if c.cursor > 0 {
 		c.cmdline = append(c.cmdline[:c.cursor-1], c.cmdline[c.cursor:]...)
 		c.cursor--
+		return
+	}
+	if len(c.cmdline) == 0 {
+		c.eventCh <- event.Event{Type: event.ExitCmdline}
 	}
 }
 


### PR DESCRIPTION
Smoothly escaping!