### PR TITLE
Copy on write bytesReaders

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -381,17 +381,6 @@ func (b *Buffer) Delete(offset int64) {
 	panic("buffer.Buffer.Delete: unreachable")
 }
 
-func (b *Buffer) clone(r readAtSeeker) readAtSeeker {
-	switch br := r.(type) {
-	case *bytesReader:
-		bs := make([]byte, len(br.bs))
-		copy(bs, br.bs)
-		return newBytesReader(bs)
-	default:
-		return r
-	}
-}
-
 func (b *Buffer) cleanup() {
 	for i := 0; i < len(b.rrs); i++ {
 		if b.rrs[i].min == b.rrs[i].max {

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -143,7 +143,7 @@ func (b *Buffer) Clone() *Buffer {
 	newBuf := new(Buffer)
 	newBuf.rrs = make([]readerRange, len(b.rrs))
 	for i, rr := range b.rrs {
-		newBuf.rrs[i] = readerRange{b.clone(rr.r), rr.min, rr.max, rr.diff}
+		newBuf.rrs[i] = readerRange{rr.r, rr.min, rr.max, rr.diff}
 	}
 	newBuf.index = b.index
 	newBuf.mu = new(sync.Mutex)
@@ -165,14 +165,7 @@ func (b *Buffer) Copy(start, end int64) *Buffer {
 			continue
 		}
 		max := mathutil.MinInt64(end-index, rr.max-index)
-		switch br := rr.r.(type) {
-		case *bytesReader:
-			bs := make([]byte, max)
-			copy(bs, br.bs[index+rr.diff:])
-			newBuf.rrs = append(newBuf.rrs, readerRange{newBytesReader(bs), index - start, index - start + max, -index + start})
-		default:
-			newBuf.rrs = append(newBuf.rrs, readerRange{br, index - start, index - start + max, rr.diff + start})
-		}
+		newBuf.rrs = append(newBuf.rrs, readerRange{rr.r, index - start, index - start + max, rr.diff + start})
 		index += max
 	}
 	newBuf.rrs = append(newBuf.rrs, readerRange{newBytesReader(nil), index - start, math.MaxInt64, -index + start})
@@ -205,29 +198,15 @@ func (b *Buffer) Cut(start, end int64) {
 		}
 		if start >= rr.min {
 			max = start - index
-			switch br := rr.r.(type) {
-			case *bytesReader:
-				bs := make([]byte, max)
-				copy(bs, br.bs[index+rr.diff:])
-				rrs = append(rrs, readerRange{newBytesReader(bs), index, index + max, -index})
-			default:
-				rrs = append(rrs, readerRange{br, index, index + max, rr.diff})
-			}
+			rrs = append(rrs, readerRange{rr.r, index, index + max, rr.diff})
 			index += max
 		}
 		if end < rr.max {
 			max = rr.max - end
-			switch br := rr.r.(type) {
-			case *bytesReader:
-				bs := make([]byte, max)
-				copy(bs, br.bs[end+rr.diff:])
-				rrs = append(rrs, readerRange{newBytesReader(bs), index, index + max, -index})
-			default:
-				if rr.max == math.MaxInt64 {
-					max = math.MaxInt64 - index
-				}
-				rrs = append(rrs, readerRange{br, index, index + max, rr.diff + end - index})
+			if rr.max == math.MaxInt64 {
+				max = math.MaxInt64 - index
 			}
+			rrs = append(rrs, readerRange{rr.r, index, index + max, rr.diff + end - index})
 			index += max
 		}
 	}
@@ -254,11 +233,11 @@ func (b *Buffer) Paste(offset int64, c *Buffer) {
 		}
 		if offset < rr.min {
 			max = mathutil.MinInt64(rr.max, math.MaxInt64-index+rr.min) + index - rr.min
-			rrs = append(rrs, readerRange{b.clone(rr.r), index, max, rr.diff - index + rr.min})
+			rrs = append(rrs, readerRange{rr.r, index, max, rr.diff - index + rr.min})
 			index = max
 			continue
 		}
-		rrs = append(rrs, readerRange{b.clone(rr.r), rr.min, offset, rr.diff})
+		rrs = append(rrs, readerRange{rr.r, rr.min, offset, rr.diff})
 		index = offset
 		for _, rr := range c.rrs {
 			if rr.max == math.MaxInt64 {
@@ -267,11 +246,11 @@ func (b *Buffer) Paste(offset int64, c *Buffer) {
 			} else {
 				max = rr.max - rr.min + index
 			}
-			rrs = append(rrs, readerRange{b.clone(rr.r), index, max, rr.diff - index + rr.min})
+			rrs = append(rrs, readerRange{rr.r, index, max, rr.diff - index + rr.min})
 			index = max
 		}
 		max = mathutil.MinInt64(rr.max, math.MaxInt64-index+offset) + index - offset
-		rrs = append(rrs, readerRange{b.clone(rr.r), index, max, rr.diff - index + offset})
+		rrs = append(rrs, readerRange{rr.r, index, max, rr.diff - index + offset})
 		index = max
 	}
 	b.rrs = rrs
@@ -306,7 +285,7 @@ func (b *Buffer) Insert(offset int64, c byte) {
 		copy(b.rrs[i+2:], b.rrs[i:])
 		b.rrs[i] = readerRange{rr.r, rr.min, offset, rr.diff}
 		b.rrs[i+1] = readerRange{newBytesReader([]byte{c}), offset, offset + 1, -offset}
-		b.rrs[i+2] = readerRange{b.clone(rr.r), offset + 1, mathutil.MinInt64(rr.max, math.MaxInt64-1) + 1, rr.diff - 1}
+		b.rrs[i+2] = readerRange{rr.r, offset + 1, mathutil.MinInt64(rr.max, math.MaxInt64-1) + 1, rr.diff - 1}
 		for i = i + 3; i < len(b.rrs); i++ {
 			b.rrs[i].min++
 			b.rrs[i].max = mathutil.MinInt64(b.rrs[i].max, math.MaxInt64-1) + 1
@@ -350,7 +329,7 @@ func (b *Buffer) Replace(offset int64, c byte) {
 		copy(b.rrs[i+2:], b.rrs[i:])
 		b.rrs[i] = readerRange{rr.r, rr.min, offset, rr.diff}
 		b.rrs[i+1] = readerRange{newBytesReader([]byte{c}), offset, offset + 1, -offset}
-		b.rrs[i+2] = readerRange{b.clone(rr.r), offset + 1, rr.max, rr.diff}
+		b.rrs[i+2] = readerRange{rr.r, offset + 1, rr.max, rr.diff}
 		b.cleanup()
 		return
 	}

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -426,8 +426,12 @@ func (b *Buffer) cleanup() {
 		case *bytesReader:
 			switch r2 := rr2.r.(type) {
 			case *bytesReader:
-				r1.bs = append(r1.bs[:rr1.max+rr1.diff], r2.bs[rr2.min+rr2.diff:]...)
+				bs := make([]byte, int(rr1.max-rr1.min)+len(r2.bs)-int(rr2.min+rr2.diff))
+				copy(bs, r1.bs[rr1.min+rr1.diff:rr1.max+rr1.diff])
+				copy(bs[rr1.max-rr1.min:], r2.bs[rr2.min+rr2.diff:])
+				b.rrs[i-1].r = newBytesReader(bs)
 				b.rrs[i-1].max = b.rrs[i].max
+				b.rrs[i-1].diff = -b.rrs[i-1].min
 				copy(b.rrs[i:], b.rrs[i+1:])
 				b.rrs = b.rrs[:len(b.rrs)-1]
 				i--

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -289,7 +289,9 @@ func (b *Buffer) Insert(offset int64, c byte) {
 		if offset == rr.min && i > 0 {
 			switch r := b.rrs[i-1].r.(type) {
 			case *bytesReader:
+				r = r.clone()
 				r.replaceByte(offset+b.rrs[i-1].diff, c)
+				b.rrs[i-1].r = r
 				b.rrs[i-1].max++
 				for ; i < len(b.rrs); i++ {
 					b.rrs[i].min++
@@ -326,13 +328,17 @@ func (b *Buffer) Replace(offset int64, c byte) {
 		}
 		switch r := rr.r.(type) {
 		case *bytesReader:
+			r = r.clone()
 			r.replaceByte(offset+rr.diff, c)
+			b.rrs[i].r = r
 			return
 		}
 		if offset == rr.min && i > 0 {
 			switch r := b.rrs[i-1].r.(type) {
 			case *bytesReader:
+				r = r.clone()
 				r.replaceByte(offset+b.rrs[i-1].diff, c)
+				b.rrs[i-1].r = r
 				b.rrs[i-1].max++
 				b.rrs[i].min++
 				b.cleanup()
@@ -361,7 +367,9 @@ func (b *Buffer) Delete(offset int64) {
 		}
 		switch r := rr.r.(type) {
 		case *bytesReader:
+			r = r.clone()
 			r.deleteByte(offset + rr.diff)
+			b.rrs[i].r = r
 			b.rrs[i].max--
 			for i++; i < len(b.rrs); i++ {
 				b.rrs[i].min--

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -2,7 +2,6 @@ package buffer
 
 import (
 	"io"
-	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -224,14 +223,6 @@ func TestBufferCopy(t *testing.T) {
 		if !strings.HasPrefix(string(p), testCase.expected+"\x00") {
 			t.Errorf("Copy(%d, %d) should clone %q but got %q", testCase.start, testCase.end, testCase.expected, string(p))
 		}
-		for _, rr := range got.rrs {
-			switch br := rr.r.(type) {
-			case *bytesReader:
-				if rr.max != math.MaxInt64 && int64(len(br.bs)) != rr.max-rr.min || rr.min+rr.diff != 0 {
-					t.Errorf("invalid bytesReader after Copy(%d, %d): %#v %#v", testCase.start, testCase.end, br, rr)
-				}
-			}
-		}
 		got.Insert(0, 0x48)
 		got.Insert(int64(len(testCase.expected)+1), 0x49)
 		p = make([]byte, 19)
@@ -280,14 +271,6 @@ func TestBufferCut(t *testing.T) {
 		_, _ = got.Read(p)
 		if !strings.HasPrefix(string(p), testCase.expected+"\x00") {
 			t.Errorf("Cut(%d, %d) should result into %q but got %q", testCase.start, testCase.end, testCase.expected, string(p))
-		}
-		for _, rr := range got.rrs {
-			switch br := rr.r.(type) {
-			case *bytesReader:
-				if rr.max != math.MaxInt64 && int64(len(br.bs)) != rr.max-rr.min || rr.min+rr.diff != 0 {
-					t.Errorf("invalid bytesReader after Cut(%d, %d): %#v %#v", testCase.start, testCase.end, br, rr)
-				}
-			}
 		}
 		got.Insert(0, 0x48)
 		got.Insert(int64(len(testCase.expected)+1), 0x49)

--- a/buffer/bytes.go
+++ b/buffer/bytes.go
@@ -68,3 +68,9 @@ func (r *bytesReader) deleteByte(offset int64) {
 	copy(r.bs[offset:], r.bs[offset+1:])
 	r.bs = r.bs[:len(r.bs)-1]
 }
+
+func (r *bytesReader) clone() *bytesReader {
+	bs := make([]byte, len(r.bs))
+	copy(bs, r.bs)
+	return newBytesReader(bs)
+}


### PR DESCRIPTION
When I started implementation of Buffer, I tried to overwrite the previous bytesReader as much as possible (ex. using replaceByte instead of splitting the slice and concatenating again) to reduce the number of slice allocation. But it became apparently a failure when I implemented the history feature. Since Buffer#Clone deeply clones the byte slices, editing a byte causes cloning all the byte slices in the buffer to push to the history. From this pull request the pointer to bytesReader will be reused as much as possible. Buffer#Clone now stop cloning the byte slices and it leads to less memory consumption.