### PR TITLE
Place a cursor at the smaller position after copying in visual mode

### DIFF
--- a/window/window.go
+++ b/window/window.go
@@ -811,12 +811,10 @@ func (w *window) copy() *buffer.Buffer {
 	if start > end {
 		start, end = end, start
 	}
-	w.cursor = w.visualStart
+	w.cursor = start
 	w.visualStart = -1
 	if w.cursor < w.offset {
 		w.offset = w.cursor / w.width * w.width
-	} else if w.cursor >= w.offset+w.height*w.width {
-		w.offset = (w.cursor - w.height*w.width + w.width) / w.width * w.width
 	}
 	return w.buffer.Copy(start, end+1)
 }


### PR DESCRIPTION
If you have intentionally decided to adopt the current behavior, I'm willing to withdraw this PR.

Note that `the smaller position` in the title refers to the smaller of `start` and `end` in line 810 of `window/window.go`.