### PR TITLE
Improve replace mode

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -20,6 +20,7 @@ type Editor struct {
 	prevMode      mode.Mode
 	searchTarget  string
 	searchMode    rune
+	replaceByte   int // the number of events required by replace command (r).
 	prevEventType event.Type
 	buffer        *buffer.Buffer
 	err           error
@@ -120,6 +121,24 @@ func (e *Editor) emit(ev event.Event) (redraw bool, finish bool) {
 	if ev.Type != event.Redraw {
 		e.prevEventType = ev.Type
 	}
+	if e.replaceByte > 0 {
+		switch ev.Type {
+		case event.Rune:
+		default:
+			e.mu.Unlock()
+			return
+		}
+		e.replaceByte--
+		if e.replaceByte == 0 {
+			e.mode, e.prevMode = mode.Normal, e.mode
+		}
+		ev.Mode = mode.Replace
+		width, height := e.ui.Size()
+		e.wm.Resize(width, height-1)
+		e.mu.Unlock()
+		e.wm.Emit(ev)
+		return
+	}
 	switch ev.Type {
 	case event.QuitAll:
 		if len(ev.Arg) > 0 {
@@ -170,7 +189,10 @@ func (e *Editor) emit(ev event.Event) (redraw bool, finish bool) {
 		switch ev.Type {
 		case event.StartInsert, event.StartInsertHead, event.StartAppend, event.StartAppendEnd:
 			e.mode, e.prevMode = mode.Insert, e.mode
-		case event.StartReplaceByte, event.StartReplace:
+		case event.StartReplaceByte:
+			e.mode, e.prevMode = mode.Replace, e.mode
+			e.replaceByte = 2 // expect 2 events
+		case event.StartReplace:
 			e.mode, e.prevMode = mode.Replace, e.mode
 		case event.ExitInsert:
 			e.mode, e.prevMode = mode.Normal, e.mode

--- a/window/window.go
+++ b/window/window.go
@@ -703,7 +703,7 @@ func (w *window) startReplaceByte() {
 
 func (w *window) startReplace() {
 	w.replaceByte = false
-	w.append = false
+	w.append = true
 	w.extending = false
 	w.pending = false
 }
@@ -768,9 +768,6 @@ func (w *window) insertByte(m mode.Mode, b byte) {
 				w.length++
 			}
 			w.cursor++
-			if w.cursor == w.length {
-				w.append = true
-			}
 		}
 		w.pending = false
 		w.pendingByte = '\x00'

--- a/window/window.go
+++ b/window/window.go
@@ -758,22 +758,26 @@ func (w *window) insertByte(m mode.Mode, b byte) {
 			w.cursor++
 			w.length++
 		case mode.Replace:
+			if w.replaceByte {
+				w.replace(w.cursor, w.pendingByte|b)
+				w.exitInsert()
+				return
+			}
 			w.replaceBuf = append(w.replaceBuf, w.pendingByte|b)
 			if w.length == 0 {
 				w.length++
 			}
-			if w.replaceByte {
-				w.exitInsert()
-			} else {
-				w.cursor++
-				if w.cursor == w.length {
-					w.append = true
-				}
+			w.cursor++
+			if w.cursor == w.length {
+				w.append = true
 			}
 		}
 		w.pending = false
 		w.pendingByte = '\x00'
 	} else {
+		if m == mode.Replace && w.replaceByte && w.length == 0 {
+			return
+		}
 		w.pending = true
 		w.pendingByte = b << 4
 	}

--- a/window/window.go
+++ b/window/window.go
@@ -29,6 +29,7 @@ type window struct {
 	cursor      int64
 	length      int64
 	stack       []position
+	replaceBuf  []byte
 	append      bool
 	replaceByte bool
 	extending   bool
@@ -158,7 +159,7 @@ func (w *window) run() {
 		case event.Rune:
 			w.insertRune(e.Mode, e.Rune)
 		case event.Backspace:
-			w.backspace()
+			w.backspace(e.Mode)
 		case event.Delete:
 			w.deleteByte()
 		case event.StartVisual:
@@ -286,10 +287,29 @@ func (w *window) positionToOffset(pos event.Position) (int64, error) {
 func (w *window) state(width, height int) (*state.WindowState, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	length := w.length
+	if len(w.replaceBuf) > 0 && w.cursor > w.length {
+		w.length = w.cursor + 1
+	}
 	w.setSize(width, height)
+	w.length = length
 	n, bytes, err := w.readBytes(w.offset, int(w.height*w.width))
 	if err != nil {
 		return nil, err
+	}
+	if l := len(w.replaceBuf); l > 0 {
+		c := w.cursor - w.offset
+		if c > int64(cap(bytes)) {
+			newSlice := make([]byte, c)
+			copy(newSlice, bytes)
+			bytes = newSlice
+		}
+		m := mathutil.MaxInt64(c-int64(l), 0)
+		copy(bytes[m:], w.replaceBuf[int64(l)-mathutil.MinInt64(int64(l), c):])
+		if x := c - int64(n); x > 0 {
+			n += int(x)
+			length += x
+		}
 	}
 	return &state.WindowState{
 		Name:          w.name,
@@ -298,7 +318,7 @@ func (w *window) state(width, height int) (*state.WindowState, error) {
 		Cursor:        w.cursor,
 		Bytes:         bytes,
 		Size:          n,
-		Length:        w.length,
+		Length:        length,
 		Pending:       w.pending,
 		PendingByte:   w.pendingByte,
 		VisualStart:   w.visualStart,
@@ -690,6 +710,15 @@ func (w *window) startReplace() {
 
 func (w *window) exitInsert() {
 	w.pending = false
+	if l := len(w.replaceBuf); l > 0 {
+		if x := w.cursor - w.length; x > 0 {
+			w.length += x
+		}
+		for i, b := range w.replaceBuf {
+			w.replace(w.cursor-int64(l-i), b)
+		}
+		w.replaceBuf = w.replaceBuf[:0]
+	}
 	if w.append {
 		if w.extending && w.length > 0 {
 			w.length--
@@ -729,7 +758,7 @@ func (w *window) insertByte(m mode.Mode, b byte) {
 			w.cursor++
 			w.length++
 		case mode.Replace:
-			w.replace(w.cursor, w.pendingByte|b)
+			w.replaceBuf = append(w.replaceBuf, w.pendingByte|b)
 			if w.length == 0 {
 				w.length++
 			}
@@ -739,8 +768,6 @@ func (w *window) insertByte(m mode.Mode, b byte) {
 				w.cursor++
 				if w.cursor == w.length {
 					w.append = true
-					w.extending = true
-					w.length++
 				}
 			}
 		}
@@ -752,11 +779,20 @@ func (w *window) insertByte(m mode.Mode, b byte) {
 	}
 }
 
-func (w *window) backspace() {
+func (w *window) backspace(m mode.Mode) {
 	if w.pending {
 		w.pending = false
 		w.pendingByte = '\x00'
 	} else if w.cursor > 0 {
+		if m == mode.Replace {
+			l := len(w.replaceBuf)
+			if l == 0 {
+				return
+			}
+			w.cursor--
+			w.replaceBuf = w.replaceBuf[:l-1]
+			return
+		}
 		w.delete(w.cursor - 1)
 		w.cursor--
 		w.length--

--- a/window/window_test.go
+++ b/window/window_test.go
@@ -966,11 +966,11 @@ func TestWindowReplaceByteEmpty(t *testing.T) {
 	window.insertByte(mode.Replace, 0x03)
 	window.insertByte(mode.Replace, 0x0a)
 	s, _ = window.state(width, height)
-	if !strings.HasPrefix(string(s.Bytes), ":\x00") {
-		t.Errorf("s.Bytes should start with %q but got %q", ":\x00", string(s.Bytes))
+	if strings.HasPrefix(string(s.Bytes), ":\x00") {
+		t.Errorf("s.Bytes should not start with %q but got %q", ":\x00", string(s.Bytes))
 	}
-	if s.Length != 1 {
-		t.Errorf("s.Length should be %d but got %d", 1, s.Length)
+	if s.Length != 0 {
+		t.Errorf("s.Length should be %d but got %d", 0, s.Length)
 	}
 	if s.Cursor != 0 {
 		t.Errorf("s.Cursor should be %d but got %d", 0, s.Cursor)

--- a/window/window_test.go
+++ b/window/window_test.go
@@ -1091,16 +1091,16 @@ func TestWindowBackspace(t *testing.T) {
 
 	window.cursorNext(mode.Normal, 5)
 	window.startInsert()
-	window.backspace()
+	window.backspace(mode.Insert)
 	s, _ := window.state(width, height)
 	if !strings.HasPrefix(string(s.Bytes), "Hell, world!\x00") {
 		t.Errorf("s.Bytes should start with %q but got %q", "Hell, world!\x00", string(s.Bytes))
 	}
-	window.backspace()
-	window.backspace()
-	window.backspace()
-	window.backspace()
-	window.backspace()
+	window.backspace(mode.Insert)
+	window.backspace(mode.Insert)
+	window.backspace(mode.Insert)
+	window.backspace(mode.Insert)
+	window.backspace(mode.Insert)
 	s, _ = window.state(width, height)
 	if !strings.HasPrefix(string(s.Bytes), ", world!\x00") {
 		t.Errorf("s.Bytes should start with %q but got %q", ", world!\x00", string(s.Bytes))
@@ -1124,7 +1124,7 @@ func TestWindowBackspacePending(t *testing.T) {
 		t.Errorf("s.PendingByte should be %q but got %q", '\x30', s.PendingByte)
 	}
 
-	window.backspace()
+	window.backspace(mode.Insert)
 	s, _ = window.state(width, height)
 	if !strings.HasPrefix(string(s.Bytes), "Hello, world!\x00") {
 		t.Errorf("s.Bytes should start with %q but got %q", "Hello, world!\x00", string(s.Bytes))


### PR DESCRIPTION
1. Now the replace-byte command (r) only replace 1 byte.
2. `r` command does nothing for empty windows.
3. In replace mode backspace does not delete original text.

But there are some issues:
1. Panic (`integer divide by zero`) occurs when interleaved with `x` command.
2. It is not trivial to determine what should happen when moving a cursor by arrow keys in replace mode.

I guess `Buffer.Replace` should increment the length when `offset` for replacing equals `length` so that in `buffer/buffer_test.go`, `TestBufferReplace`'s last 3 test cases should set `len` to 17.

https://github.com/itchyny/bed/blob/517e02f6511bbed890f2df35636c6f88bebd21d0/buffer/buffer_test.go#L400-L402

Related to #12.