### PR TITLE
Proposal: add "gb" command analogous to "ga" and "g8" of Vim

### DIFF
--- a/editor/editor_test.go
+++ b/editor/editor_test.go
@@ -431,3 +431,39 @@ func TestEditorCopyCutPaste(t *testing.T) {
 		t.Errorf("file contents should be %q but got %q", expected, string(bs))
 	}
 }
+
+func TestEditorShowBinary(t *testing.T) {
+	ui := newTestUI()
+	editor := NewEditor(ui, window.NewManager(), cmdline.NewCmdline())
+	if err := editor.Init(); err != nil {
+		t.Errorf("err should be nil but got: %v", err)
+	}
+	f, err := ioutil.TempFile("", "bed-test-editor-show-binary")
+	if err != nil {
+		t.Errorf("err should be nil but got: %v", err)
+	}
+	_, _ = f.WriteString("Hello, world!")
+	if err := f.Close(); err != nil {
+		t.Errorf("err should be nil but got: %v", err)
+	}
+	defer os.Remove(f.Name())
+	if err := editor.Open(f.Name()); err != nil {
+		t.Errorf("err should be nil but got: %v", err)
+	}
+	go func() {
+		ui.Emit(event.Event{Type: event.ShowBinary})
+		ui.Emit(event.Event{Type: event.Quit})
+	}()
+	if err := editor.Run(); err != nil {
+		t.Errorf("err should be nil but got: %v", err)
+	}
+	if editor.errtyp != state.MessageInfo {
+		t.Errorf("errtyp should be MessageInfo but got: %v", editor.errtyp)
+	}
+	if msg, expected := editor.err.Error(), "01001000"; msg != expected {
+		t.Errorf("message should be %q but got: %q", expected, msg)
+	}
+	if err := editor.Close(); err != nil {
+		t.Errorf("err should be nil but got: %v", err)
+	}
+}

--- a/editor/key.go
+++ b/editor/key.go
@@ -61,6 +61,7 @@ func defaultKeyManagers() map[mode.Mode]*key.Manager {
 	km.Register(event.Increment, "+")
 	km.Register(event.Decrement, "c-x")
 	km.Register(event.Decrement, "-")
+	km.Register(event.ShowBinary, "g", "b")
 
 	km.Register(event.Paste, "p")
 	km.Register(event.PastePrev, "P")

--- a/event/event.go
+++ b/event/event.go
@@ -60,6 +60,7 @@ const (
 	Increment
 	Decrement
 	SwitchFocus
+	ShowBinary
 
 	StartInsert
 	StartInsertHead

--- a/window/window.go
+++ b/window/window.go
@@ -3,6 +3,7 @@ package window
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"sync"
@@ -156,6 +157,9 @@ func (w *window) emit(e event.Event) {
 		w.increment(e.Count)
 	case event.Decrement:
 		w.decrement(e.Count)
+
+	case event.ShowBinary:
+		w.showBinary()
 
 	case event.StartInsert:
 		w.startInsert()
@@ -711,6 +715,15 @@ func (w *window) decrement(count int64) {
 	if w.length == 0 {
 		w.length++
 	}
+}
+
+// showBinary shows in binary format an 8-bit integer at the cursor.
+func (w *window) showBinary() {
+	n, bytes, err := w.readBytes(w.cursor, 1)
+	if err != nil || n == 0 {
+		return
+	}
+	w.eventCh <- event.Event{Type: event.Info, Error: fmt.Errorf("%08b", bytes[0])}
 }
 
 func (w *window) startInsert() {


### PR DESCRIPTION
## Description
It shows a byte in binary format. Useful to see bit patterns.

## Name

The name `gb` (for binary) is just by analogy with `ga` (for ASCII) and `g8` (for UTF-8) commands of Vim.

## Why
I need this feature to debug an assembler.