### PR TITLE
Support replacing in visual mode

### DIFF
--- a/buffer/const.go
+++ b/buffer/const.go
@@ -1,0 +1,21 @@
+package buffer
+
+type constReader byte
+
+// Read implements the io.Reader interface.
+func (r constReader) Read(b []byte) (int, error) {
+	for i := range b {
+		b[i] = byte(r)
+	}
+	return len(b), nil
+}
+
+// Seek implements the io.Seeker interface.
+func (r constReader) Seek(offset int64, whence int) (int64, error) {
+	return 0, nil
+}
+
+// ReadAt implements the io.ReaderAt interface.
+func (r constReader) ReadAt(b []byte, offset int64) (int, error) {
+	return r.Read(b)
+}

--- a/editor/key.go
+++ b/editor/key.go
@@ -144,6 +144,7 @@ func defaultKeyManagers() map[mode.Mode]*key.Manager {
 	km.Register(event.SwitchVisualEnd, "o")
 	km.Register(event.SwitchVisualEnd, "O")
 	km.Register(event.StartCmdlineCommand, ":")
+	km.Register(event.StartReplaceByte, "r")
 
 	km.Register(event.CursorUp, "up")
 	km.Register(event.CursorDown, "down")

--- a/window/window.go
+++ b/window/window.go
@@ -353,6 +353,11 @@ func (w *window) undoReplace(offset int64) {
 	w.changedTick++
 }
 
+func (w *window) replaceIn(start, end int64, c byte) {
+	w.buffer.ReplaceIn(start, end, c)
+	w.changedTick++
+}
+
 func (w *window) delete(offset int64) {
 	w.buffer.Delete(offset)
 	w.changedTick++
@@ -824,6 +829,15 @@ func (w *window) insertByte(m mode.Mode, b byte) bool {
 			w.cursor++
 			w.length++
 		case mode.Replace:
+			if w.visualStart >= 0 && w.replaceByte {
+				start, end := w.visualStart, w.cursor
+				if start > end {
+					start, end = end, start
+				}
+				w.replaceIn(start, end+1, w.pendingByte|b)
+				w.visualStart = -1
+				return true
+			}
 			w.replace(w.cursor, w.pendingByte|b)
 			if w.length == 0 {
 				w.length++


### PR DESCRIPTION
Add `r` command in visual mode. It behaves like Vim's one.