### PR TITLE
Extend some commands of normal mode to visual mode

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -197,7 +197,11 @@ func (e *Editor) emit(ev event.Event) (redraw bool, finish bool) {
 		case event.ExitCmdline:
 			e.mode, e.prevMode = mode.Normal, e.mode
 		case event.ExecuteCmdline:
-			e.mode, e.prevMode = mode.Normal, e.mode
+			m := mode.Normal
+			if e.mode == mode.Search {
+				m = e.prevMode
+			}
+			e.mode, e.prevMode = m, e.mode
 		case event.ExecuteSearch:
 			e.searchTarget, e.searchMode = ev.Arg, ev.Rune
 		case event.NextSearch:

--- a/editor/key.go
+++ b/editor/key.go
@@ -15,14 +15,6 @@ func defaultKeyManagers() map[mode.Mode]*key.Manager {
 	km.Register(event.Quit, "c-w", "c")
 	km.Register(event.Suspend, "c-z")
 
-	km.Register(event.ScrollTopHead, "z", "enter")
-	km.Register(event.ScrollMiddle, "z", "z")
-	km.Register(event.ScrollMiddleHead, "z", ".")
-	km.Register(event.ScrollBottom, "z", "b")
-	km.Register(event.ScrollBottomHead, "z", "-")
-	km.Register(event.WindowTop, "H")
-	km.Register(event.WindowMiddle, "M")
-	km.Register(event.WindowBottom, "L")
 	km.Register(event.JumpTo, "\x1d")
 	km.Register(event.JumpBack, "c-t")
 	km.Register(event.DeleteByte, "x")
@@ -47,11 +39,6 @@ func defaultKeyManagers() map[mode.Mode]*key.Manager {
 	km.Register(event.Redo, "c-r")
 
 	km.Register(event.StartVisual, "v")
-
-	km.Register(event.StartCmdlineSearchForward, "/")
-	km.Register(event.StartCmdlineSearchBackward, "?")
-	km.Register(event.NextSearch, "n")
-	km.Register(event.PreviousSearch, "N")
 
 	km.Register(event.New, "c-w", "n")
 	km.Register(event.New, "c-w", "c-n")
@@ -170,6 +157,14 @@ func defaultNormalAndVisual() *key.Manager {
 	km.Register(event.ScrollUp, "c-y")
 	km.Register(event.ScrollDown, "c-e")
 	km.Register(event.ScrollTop, "z", "t")
+	km.Register(event.ScrollTopHead, "z", "enter")
+	km.Register(event.ScrollMiddle, "z", "z")
+	km.Register(event.ScrollMiddleHead, "z", ".")
+	km.Register(event.ScrollBottom, "z", "b")
+	km.Register(event.ScrollBottomHead, "z", "-")
+	km.Register(event.WindowTop, "H")
+	km.Register(event.WindowMiddle, "M")
+	km.Register(event.WindowBottom, "L")
 
 	km.Register(event.PageUp, "c-b")
 	km.Register(event.PageDown, "c-f")
@@ -180,6 +175,11 @@ func defaultNormalAndVisual() *key.Manager {
 
 	km.Register(event.SwitchFocus, "tab")
 	km.Register(event.SwitchFocus, "backtab")
+
+	km.Register(event.StartCmdlineSearchForward, "/")
+	km.Register(event.StartCmdlineSearchBackward, "?")
+	km.Register(event.NextSearch, "n")
+	km.Register(event.PreviousSearch, "N")
 
 	km.Register(event.StartCmdlineCommand, ":")
 	km.Register(event.StartReplaceByte, "r")


### PR DESCRIPTION
The following commands are added to **visual mode**:
```
z<Enter>
zz
z.
zb
z-
H
M
L
/
?
n
N
```

## Explanation

### The first commit

The former of the two commits is just refactoring.
Since normal mode and visual mode share many commands, it is preferred to make the common commands explicit.

### The second commit

The latter commit is what this Pull Request wants to do.
It enables 12 normal commands also in visual mode.

`editor/editor.go` is modified for the editor to get back to visual mode after a search is done which is in turn on visual mode.