### PR TITLE
Support logical shift

### DIFF
--- a/editor/editor_test.go
+++ b/editor/editor_test.go
@@ -534,7 +534,7 @@ func TestEditorShift(t *testing.T) {
 		} {
 			ui.Emit(event.Event{Type: e.typ, Rune: e.ch, Count: e.count})
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 		ui.Emit(event.Event{Type: event.WriteQuit})
 	}()
 	if err := editor.Run(); err != nil {

--- a/editor/editor_test.go
+++ b/editor/editor_test.go
@@ -510,7 +510,7 @@ func TestEditorShift(t *testing.T) {
 	if err := editor.Init(); err != nil {
 		t.Errorf("err should be nil but got: %v", err)
 	}
-	f, err := ioutil.TempFile("", "bed-test-editor-show-decimal")
+	f, err := ioutil.TempFile("", "bed-test-editor-shift")
 	if err != nil {
 		t.Errorf("err should be nil but got: %v", err)
 	}
@@ -530,7 +530,7 @@ func TestEditorShift(t *testing.T) {
 		}{
 			{event.ShiftLeft, '<', 1},
 			{event.CursorNext, 'w', 7},
-			{event.ShiftRight, '<', 3},
+			{event.ShiftRight, '>', 3},
 		} {
 			ui.Emit(event.Event{Type: e.typ, Rune: e.ch, Count: e.count})
 		}

--- a/editor/key.go
+++ b/editor/key.go
@@ -24,6 +24,8 @@ func defaultKeyManagers() map[mode.Mode]*key.Manager {
 	km.Register(event.Increment, "+")
 	km.Register(event.Decrement, "c-x")
 	km.Register(event.Decrement, "-")
+	km.Register(event.ShiftLeft, "<")
+	km.Register(event.ShiftRight, ">")
 	km.Register(event.ShowBinary, "g", "b")
 	km.Register(event.ShowDecimal, "g", "d")
 

--- a/event/event.go
+++ b/event/event.go
@@ -59,6 +59,8 @@ const (
 	DeletePrevByte
 	Increment
 	Decrement
+	ShiftLeft
+	ShiftRight
 	SwitchFocus
 	ShowBinary
 	ShowDecimal

--- a/window/window.go
+++ b/window/window.go
@@ -736,7 +736,7 @@ func (w *window) shiftLeft(count int64) {
 	if err != nil {
 		return
 	}
-	w.replace(w.cursor, bytes[0]<<byte(mathutil.MaxInt64(count, 1)%256))
+	w.replace(w.cursor, bytes[0]<<byte(mathutil.MaxInt64(count, 1)))
 	if w.length == 0 {
 		w.length++
 	}
@@ -747,7 +747,7 @@ func (w *window) shiftRight(count int64) {
 	if err != nil {
 		return
 	}
-	w.replace(w.cursor, bytes[0]>>byte(mathutil.MaxInt64(count, 1)%256))
+	w.replace(w.cursor, bytes[0]>>byte(mathutil.MaxInt64(count, 1)))
 	if w.length == 0 {
 		w.length++
 	}

--- a/window/window.go
+++ b/window/window.go
@@ -157,6 +157,10 @@ func (w *window) emit(e event.Event) {
 		w.increment(e.Count)
 	case event.Decrement:
 		w.decrement(e.Count)
+	case event.ShiftLeft:
+		w.shiftLeft(e.Count)
+	case event.ShiftRight:
+		w.shiftRight(e.Count)
 	case event.ShowBinary:
 		if str := w.showBinary(); str != "" {
 			newEvent = event.Event{Type: event.Info, Error: errors.New(str)}
@@ -722,6 +726,28 @@ func (w *window) decrement(count int64) {
 		return
 	}
 	w.replace(w.cursor, bytes[0]-byte(mathutil.MaxInt64(count, 1)%256))
+	if w.length == 0 {
+		w.length++
+	}
+}
+
+func (w *window) shiftLeft(count int64) {
+	_, bytes, err := w.readBytes(w.cursor, 1)
+	if err != nil {
+		return
+	}
+	w.replace(w.cursor, bytes[0]<<byte(mathutil.MaxInt64(count, 1)%256))
+	if w.length == 0 {
+		w.length++
+	}
+}
+
+func (w *window) shiftRight(count int64) {
+	_, bytes, err := w.readBytes(w.cursor, 1)
+	if err != nil {
+		return
+	}
+	w.replace(w.cursor, bytes[0]>>byte(mathutil.MaxInt64(count, 1)%256))
 	if w.length == 0 {
 		w.length++
 	}


### PR DESCRIPTION
The following commands are added to normal mode:

- `<`: logical left shift
- `>`: logical right shift