### PR TITLE
editor: fix dropped test error

### DIFF
--- a/editor/editor_test.go
+++ b/editor/editor_test.go
@@ -262,12 +262,15 @@ func TestEditorWritePartial(t *testing.T) {
 
 func TestEditorWriteVisualSelection(t *testing.T) {
 	f1, err := ioutil.TempFile("", "bed-test-editor-write-visual-selection1")
-	f2, err := ioutil.TempFile("", "bed-test-editor-write-visual-selection2")
-	defer os.Remove(f1.Name())
-	defer os.Remove(f2.Name())
 	if err != nil {
 		t.Errorf("err should be nil but got: %v", err)
 	}
+	defer os.Remove(f1.Name())
+	f2, err := ioutil.TempFile("", "bed-test-editor-write-visual-selection2")
+	if err != nil {
+		t.Errorf("err should be nil but got: %v", err)
+	}
+	defer os.Remove(f2.Name())
 	str := "Hello, world!"
 	n, err := f1.WriteString(str)
 	if n != 13 {


### PR DESCRIPTION
This fixes a dropped test error in the `editor` package.