### PR TITLE
window: Handle Dropped Variables

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,6 @@ github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.8 h1:3tS41NlGYSmhhe/8fhGRzc+z3AYCw1Fe1WAyLuujKs0=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756 h1:9nuHUbU8dRnRRfj9KjWUVrJeoexdbeMjttk6Oh1rD10=
 golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.8 h1:3tS41NlGYSmhhe/8fhGRzc+z3AYCw1Fe1WAyLuujKs0=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756 h1:9nuHUbU8dRnRRfj9KjWUVrJeoexdbeMjttk6Oh1rD10=
 golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/window/manager_test.go
+++ b/window/manager_test.go
@@ -55,6 +55,9 @@ func TestManagerOpenStates(t *testing.T) {
 	wm.Init(eventCh, redrawCh)
 	wm.SetSize(110, 20)
 	f, err := ioutil.TempFile("", "bed-test-manager-open")
+	if err != nil {
+		t.Errorf("err should be nil but got %v", err)
+	}
 	str := "Hello, world! こんにちは、世界！"
 	n, err := f.WriteString(str)
 	if n != 41 {

--- a/window/manager_test.go
+++ b/window/manager_test.go
@@ -329,6 +329,9 @@ func TestManagerCopyCutPaste(t *testing.T) {
 	eventCh, redrawCh, waitCh := make(chan event.Event), make(chan struct{}), make(chan struct{})
 	wm.Init(eventCh, redrawCh)
 	f, err := ioutil.TempFile("", "bed-test-manager-copy-cut-paste")
+	if err != nil {
+		t.Errorf("err should be nil but got %v", err)
+	}
 	str := "Hello, world!"
 	_, err = f.WriteString(str)
 	if err != nil {

--- a/window/window_test.go
+++ b/window/window_test.go
@@ -765,10 +765,9 @@ func TestWindowInsertByte(t *testing.T) {
 
 	window.cursorNext(mode.Normal, 7)
 	window.startInsert()
-	s, _ := window.state(width, height)
 
 	window.insertByte(mode.Insert, 0x04)
-	s, _ = window.state(width, height)
+	s, _ := window.state(width, height)
 	if s.Pending != true {
 		t.Errorf("s.Pending should be %v but got %v", true, s.Pending)
 	}


### PR DESCRIPTION
This picks up two dropped errors and removes an unused `*state.WindowState` in the tests for the `window` package.